### PR TITLE
Option to skip loading CSS.

### DIFF
--- a/wordcount/plugin.js
+++ b/wordcount/plugin.js
@@ -110,7 +110,9 @@ CKEDITOR.plugins.add("wordcount", {
 
         var format = defaultFormat;
 
-        CKEDITOR.document.appendStyleSheet(this.path + "css/wordcount.css");
+        if (config.loadCss === undefined || config.loadCss) {
+          CKEDITOR.document.appendStyleSheet(this.path + "css/wordcount.css");
+        }
 
         function counterId(editorInstance) {
             return "cke_wordcount_" + editorInstance.name;


### PR DESCRIPTION
For production environments where CSS is minified and concatenated into a single file, we need the option to skip loading the CSS from the plugin path. (We load it ourselves as part of a concatenated file.) The default is still to load the CSS as per previous behaviour.