### PR TITLE
Add filter before count

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ config.wordcount = {
     countHTML: false,
     
     // Maximum allowed Word Count that can be entered in the editor, Default Value: -1 (unlimited)
-    maxWordCount: 10,
+    maxWordCount: -1,
 
     // Maximum allowed Chararcater Count entered be in the editor, Default Value: -1 (unlimited)
-    maxCharCount: 12,
+    maxCharCount: -1,
 
     // Add filter to add or remove element before counting (see CKEDITOR.htmlParser.filter), Default value : null (no filter)
     filter: new CKEDITOR.htmlParser.filter({

--- a/README.md
+++ b/README.md
@@ -46,10 +46,21 @@ config.wordcount = {
     countHTML: false,
     
     // Maximum allowed Word Count that can be entered in the editor, Default Value: -1 (unlimited)
-    maxWordCount: -1,
+    maxWordCount: 10,
 
     // Maximum allowed Chararcater Count entered be in the editor, Default Value: -1 (unlimited)
-    maxCharCount: -1
+    maxCharCount: 12,
+
+    // Add filter to add or remove element before counting (see CKEDITOR.htmlParser.filter), Default value : null (no filter)
+    filter: new CKEDITOR.htmlParser.filter({
+        elements: {
+            div: function( element ) {
+                if(element.attributes.class == 'mediaembed') {
+                    return false;
+                }
+            }
+        }
+    })
 };
 ````
 

--- a/wordcount/plugin.js
+++ b/wordcount/plugin.js
@@ -16,6 +16,7 @@ CKEDITOR.plugins.add("wordcount", {
             limitRestoredNotified = false,
             snapShot = editor.getSnapshot();
 
+
         var dispatchEvent = function (type, currentLength, maxLength) {
             if (typeof document.dispatchEvent == 'undefined') {
                 return;
@@ -60,6 +61,9 @@ CKEDITOR.plugins.add("wordcount", {
             //MAXLENGTH Properties
             maxWordCount: -1,
             maxCharCount: -1,
+
+            // Filter
+            filter: null,
 
             //DisAllowed functions
             wordCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
@@ -125,6 +129,10 @@ CKEDITOR.plugins.add("wordcount", {
 
         function strip(html) {
             var tmp = document.createElement("div");
+
+            // Add filter before strip
+            html = filter(html);
+
             tmp.innerHTML = html;
 
             if (tmp.textContent == "" && typeof tmp.innerText == "undefined") {
@@ -132,6 +140,22 @@ CKEDITOR.plugins.add("wordcount", {
             }
 
             return tmp.textContent || tmp.innerText;
+        }
+
+        /**
+         * Implement filter to add or remove before counting
+         * @param html
+         * @returns string
+         */
+        function filter(html) {
+            if(config.filter instanceof CKEDITOR.htmlParser.filter) {
+                var fragment = CKEDITOR.htmlParser.fragment.fromHtml(html),
+                    writer = new CKEDITOR.htmlParser.basicWriter();
+                config.filter.applyTo( fragment );
+                fragment.writeHtml( writer );
+                return writer.getHtml();
+            }
+            return html;
         }
 
         function countCharacters(text, editorInstance) {


### PR DESCRIPTION
I've add a feature to filter html before counting. 

For exemple, if you don't whant to count the content of mediaembed, you add : 
```javascript
new CKEDITOR.htmlParser.filter({
        elements: {
            div: function( element ) {
                if(element.attributes.class == 'mediaembed') {
                    return false;
                }
            }
        }
})
```

Referer to the [CKEDITOR.htmlParser.filter](http://docs.ckeditor.com/#!/api/CKEDITOR.htmlParser.filter).