### PR TITLE
Fix LimitRestored when reach the max limit

### DIFF
--- a/wordcount/plugin.js
+++ b/wordcount/plugin.js
@@ -306,8 +306,8 @@ CKEDITOR.plugins.add("wordcount", {
                 (config.maxCharCount > -1 && charCount > config.maxCharCount && deltaChar > 0)) {
 
                 limitReached(editorInstance, limitReachedNotified);
-            } else if ((config.maxWordCount == -1 || wordCount < config.maxWordCount) &&
-            (config.maxCharCount == -1 || charCount < config.maxCharCount)) {
+            } else if ((config.maxWordCount == -1 || wordCount <= config.maxWordCount) &&
+            (config.maxCharCount == -1 || charCount <= config.maxCharCount)) {
 
                 limitRestored(editorInstance);
             } else {


### PR DESCRIPTION
added (<=) instead of (<) to avoid ignore the max limit on limitRestore validation.