### PR TITLE
Pass event data when calling editor.getData()

### DIFF
--- a/wordcount/plugin.js
+++ b/wordcount/plugin.js
@@ -245,7 +245,7 @@ CKEDITOR.plugins.add("wordcount", {
 
             if (!notify) {
                 counterElement(editorInstance).className = "cke_path_item cke_wordcountLimitReached";
-                editorInstance.fire("limitReached", {}, editor);
+                editorInstance.fire("limitReached", {firedBy: "wordCount.limitReached"}, editor);
             }
         }
 
@@ -264,7 +264,17 @@ CKEDITOR.plugins.add("wordcount", {
                 charCount = 0,
                 text;
 
-            if (text = editorInstance.getData()) {
+            // BeforeGetData and getData events are fired when calling
+            // getData(). We can prevent this by passing true as an
+            // argument to getData(). This allows us to fire the events
+            // manually with additional event data: firedBy. This additional
+            // data helps differentiate calls to getData() made by
+            // wordCount plugin from calls made by other plugins/code.
+            editorInstance.fire("beforeGetData", {firedBy: "wordCount.updateCounter"}, editor);
+            text = editorInstance.getData(true);
+            editorInstance.fire("getData", {dataValue: text, firedBy: "wordCount.updateCounter"}, editor);
+
+            if (text)  {
                 if (config.showCharCount) {
                     charCount = countCharacters(text, editorInstance);
                 }
@@ -389,9 +399,19 @@ CKEDITOR.plugins.add("wordcount", {
 
                 // Check if pasted content is above the limits
                 var wordCount = -1,
-                    charCount = -1,
-                    text = event.editor.getData() + event.data.dataValue;
+                    charCount = -1;
 
+                // BeforeGetData and getData events are fired when calling
+                // getData(). We can prevent this by passing true as an
+                // argument to getData(). This allows us to fire the events
+                // manually with additional event data: firedBy. This additional
+                // data helps differentiate calls to getData() made by
+                // wordCount plugin from calls made by other plugins/code.
+                event.editor.fire("beforeGetData", {firedBy: "wordCount.onPaste"}, event.editor);
+                var text = event.editor.getData(true);
+                event.editor.fire("getData", {dataValue: text, firedBy: "wordCount.onPaste"}, event.editor);
+
+                text += event.data.dataValue;
 
                 if (config.showCharCount) {
                     charCount = countCharacters(text, event.editor);


### PR DESCRIPTION
I'm developing some code that performs manipulations on editor content when CKEditor’s getData() method is called. There are 2 events that are fired when getData() is called: beforeGetData and getData. I also happen to use your wordCount plugin. However, wordCount plugins calls getData() quite often. I only want to run my code, when I save editor contents or change between wysiwyg and source mode (these two call getData() as well). Currently there is no way for me to differentiate getData() calls made by wordCount plugin and calls made by other plugins/code. So I made this little pull request which, in essence, will pass `firedBy` element along with the event data.

Also for completeness sake, I added `firedBy` element to event data passed when limitReached event is fired.

Please, let me know what you think about this change. I will make modifications to it, if needed.