### PR TITLE
Issue #144: Place the cursor at the end of the content on limitReached.

### DIFF
--- a/wordcount/plugin.js
+++ b/wordcount/plugin.js
@@ -263,6 +263,12 @@ CKEDITOR.plugins.add("wordcount", {
                 editorInstance.loadSnapshot(snapShot);
                 // lock editor
                 editorInstance.config.Locked = 1;
+
+                // Place the cursor at the end of the content after reload
+                // with the loadSnapshot().
+                var range = editorInstance.createRange();
+                range.moveToElementEditEnd(range.root);
+                editorInstance.getSelection().selectRanges([range]);
             }
 
             if (!notify) {


### PR DESCRIPTION
Fixes issue #144  **When max chars count is reached, cursor jumps to content first position.**

Attached see gif showing the fix

![cursor-position](https://user-images.githubusercontent.com/16477724/32706440-a7146800-c7da-11e7-806a-71d12548b424.gif)
