### PR TITLE
Added safety check in updateCounter function

### DIFF
--- a/wordcount/plugin.js
+++ b/wordcount/plugin.js
@@ -281,6 +281,10 @@ CKEDITOR.plugins.add("wordcount", {
         }
 
         function updateCounter(editorInstance) {
+            if(counterElement(editorInstance)){
+                return;
+            }
+
             var paragraphs = 0,
                 wordCount = 0,
                 charCount = 0,


### PR DESCRIPTION
Hello,

I just recently started using your wordCount plugin! It's been extremely helpful! :smile: 

However, I noticed that when the CKEditor is taken off the page, there are still calls to updateCounter. This would cause issues when getting the innerHTML or innerText of the element because those elements are no longer on the DOM.

The check I added should prevent any explosions like this from happening in the future. Let me know if you have any concerns around having the early return at the top of the function. 

Sincerely,
Wulfex