### PR TITLE
[BUGFIX] Composer: add valid package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,13 @@
 {
-	"name": "w8tcha/CKEditor-WordCount-Plugin",
+	"name": "w8tcha/ckeditor-wordcount-plugin",
 	"description": "WordCount Plugin for CKEditor Editor",
 	"type": "library",
 	"keywords": [ "ckeditor", "editor", "wysiwyg", "html", "richtext", "text", "javascript" ],
 	"homepage": "http://w8tcha.github.com/CKEditor-WordCount-Plugin/",
 	"license": [ "MIT" ],
+	"support": {
+		"issues": "https://github.com/w8tcha/CKEditor-WordCount-Plugin/issues"
+	},
 	"authors": [
 		{
 			"name":  "w8tcha",


### PR DESCRIPTION
Uppercase characters aren't supported. Switch to suggested
package name instead.

And add the informative support.issues url.