### PR TITLE
fix: spelling correction of word characters

### DIFF
--- a/wordcount/lang/pt-br.js
+++ b/wordcount/lang/pt-br.js
@@ -4,8 +4,8 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang('wordcount', 'pt-br', {
     WordCount: 'Contagem de palavras:',
-    CharCount: 'Contagem de carateres:',
-    CharCountWithHTML: 'Carateres (incluindo HTML):',
+    CharCount: 'Contagem de caracteres:',
+    CharCountWithHTML: 'Caracteres (incluindo HTML):',
     Paragraphs: 'Parágrafos:',
     ParagraphsRemaining: 'Paragraphs remaining',
     pasteWarning: 'Conteúdo não pode ser colado porque ultrapassa o limite permitido',


### PR DESCRIPTION
The word "carateres" is incorrect in pt-br, the correct one is "caracteres"